### PR TITLE
Fix for shorter if let lifetime

### DIFF
--- a/sylt-common/src/value.rs
+++ b/sylt-common/src/value.rs
@@ -120,10 +120,11 @@ impl Value {
         match self {
             Value::Ty(ty) => write!(fmt, "<type \"{:?}\">", ty),
             Value::Blob(v) => {
+                let v_ref = v.borrow();
                 write!(
                     fmt,
                     "{} (0x{:x}) {{",
-                    if let Some(Value::String(name)) = v.borrow().get("_name") {
+                    if let Some(Value::String(name)) = v_ref.get("_name") {
                         name.as_str()
                     } else {
                         unreachable!("Got blob without a name")


### PR DESCRIPTION
Context: Rust compiler PR https://github.com/rust-lang/rust/pull/107251 wants to change the lifetime of things inside the `if let` matcher. The PR would break the build of this project (out of only a handful of breakages):

```Rust
error[E0716]: temporary value dropped while borrowed
   --> sylt-common/src/value.rs:126:56
    |
126 |                       if let Some(Value::String(name)) = v.borrow().get("_name") {
    |                       -                                  ^^^^^^^^^^ creates a temporary value which is freed while still in use
    |  _____________________|
    | |
127 | |                         name.as_str()
128 | |                     } else {
    | |                     - temporary value is freed at the end of this statement
129 | |                         unreachable!("Got blob without a name")
130 | |                     },
    | |_____________________- borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
```

The new version compiles both before and after the PR. Thanks for taking a look!